### PR TITLE
Fixing bug in isPHPVersionMoreRecentThan

### DIFF
--- a/API.php
+++ b/API.php
@@ -305,26 +305,12 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * A private methode to save the company details in the DB
-     * @param array    $data
+     * A private method to determine if installed PHP version is above a certain version threshold
+     * @param string $version
      * @return boolean
      */
     private function isPHPVersionMoreRecentThan($version)
     {
-        $phpVersion         = phpversion();
-        $phpVersionParts    = explode(".", $phpVersion);
-        $phpMinVersionParts = explode(".", $version);
-
-        if((int)$phpVersionParts[0] < (int)$phpMinVersionParts[0]) {
-            return FALSE;
-        }
-        elseif((int)$phpVersionParts[1] < (int)$phpMinVersionParts[1]) {
-            return FALSE;
-        }
-        elseif((int)$phpVersionParts[2] < (int)$phpMinVersionParts[2]) {
-            return FALSE;
-        }
-
-        return TRUE;
+        return version_compare(phpversion(), $version, '>');
     }
 }


### PR DESCRIPTION
If the installed version is 8.1, and the function is called with the string 7.4, it should return true because 8.1 is more recent than 7.4. however it returns false, because the first conditional check fails, so we fall through to the second conditional (the elseif). 

The problem with this second conditional is that it only examines the minor version, not taking into account the major version. So in our example, it compares 1 to 4. Since 1 is less than 4, this condition succeeds, and the function returns false.

This fix also simplifies the function by using a native PHP method that is purpose built for this use case