### PR TITLE
Fixed filter deprecations on PHP 8.1

### DIFF
--- a/UserSettings.php
+++ b/UserSettings.php
@@ -45,7 +45,7 @@ class UserSettings extends \Piwik\Settings\Plugin\UserSettings
     public function getSubscribedToEmailReportValueForUser($userLogin)
     {
         // Sanitize the user login
-        $userLogin = filter_var($userLogin, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH);
+        $userLogin = htmlspecialchars($userLogin);
 
         try {
             $sql = "SELECT * FROM " . Common::prefixTable('plugin_setting') . "


### PR DESCRIPTION
Removes deprecated on PHP 8.1 constant FILTER_SANITIZE_STRING usage.

https://www.php.net/manual/en/filter.filters.sanitize.php

> Strip tags and HTML-encode double and single quotes, optionally strip or encode special characters. Encoding quotes can be disabled by setting FILTER_FLAG_NO_ENCODE_QUOTES. (Deprecated as of PHP 8.1.0, use [htmlspecialchars()](https://www.php.net/manual/en/function.htmlspecialchars.php) instead.)
